### PR TITLE
launch 'confirm photo' activity after picture is accepted

### DIFF
--- a/app/src/main/java/nrdzs/cs465/illinois/edu/spot/CustomActivity.java
+++ b/app/src/main/java/nrdzs/cs465/illinois/edu/spot/CustomActivity.java
@@ -98,5 +98,8 @@ public class CustomActivity extends Activity {
                 e.printStackTrace();
             }
         }
+
+        Intent launchConfirmPhoto = new Intent(this, ConfirmPhotoLocationActivity.class);
+        startActivity(launchConfirmPhoto);
     }
 }


### PR DESCRIPTION
link from "take photo" to "confirm photo location". No data passed yet since the photo is not actually shown on the confirm screen